### PR TITLE
Make use of std::atomic conditional on -DATOMIC

### DIFF
--- a/src/pow/cuckoo_cycle/cuckoo_cycle.h
+++ b/src/pow/cuckoo_cycle/cuckoo_cycle.h
@@ -89,7 +89,11 @@ public:
     int next_nonce;
     static int last_err;               ///< last error after call to is_valid()
     bool external_nonce;
+#if ATOMIC
     std::atomic<bool>* pAbort;
+#else
+    bool* pAbort;
+#endif
     cuckoo_cycle(cc_challenge_ref c_in, callback_ref cb_in = nullptr, bool external_nonce_in = true)
     : pow(POWID_CUCKOO_CYCLE, c_in, cb_in), thread(nullptr), c(c_in), next_nonce(0), external_nonce(external_nonce_in), pAbort(NULL) {}
     ~cuckoo_cycle();

--- a/src/pow/cuckoo_cycle/cuckoo_miner.h
+++ b/src/pow/cuckoo_cycle/cuckoo_miner.h
@@ -233,7 +233,11 @@ public:
   uint16_t proofsize_min;
   uint16_t proofsize_max;
   pthread_barrier_t barry;
+#if ATOMIC
   std::atomic<bool> abort;
+#else
+  bool abort;
+#endif
 
   cuckoo_ctx(u32 n_threads, u32 n_trims, u32 max_sols, uint16_t proofsize_min_in, uint16_t proofsize_max_in) {
     abort = false;


### PR DESCRIPTION
@kallewoof is the abort functionality something you added? It's declared with `std::atomic`, but not guarded by `-DATOMIC` like  the other atomic code is in the cuckoo cycle code. This PR makes it a regular bool if `-DATOMIC` is not used, which is the default on my laptop build environment.

(Incidentally, is this safe? I haven't thoroughly investigated to see what you are doing here, and if I should be using the atomic primitives.)